### PR TITLE
fix rss feed not validating due to invalid tz

### DIFF
--- a/lib/Labyrinth/DTUtils.pm
+++ b/lib/Labyrinth/DTUtils.pm
@@ -274,7 +274,7 @@ sub formatDate {
     my $fhour   = sprintf "%02d", $dt->hour;
     my $fminute = sprintf "%02d", $dt->minute;
     my $fsecond = sprintf "%02d", $dt->second;
-    my $tz      = 'UTC';
+    my $tz      = 'GMT'; # RFC822 requires GMT not UTC
     eval { $tz = $dt->time_zone->short_name_for_datetime };
 
     my $fmt = $formats{$format};


### PR DESCRIPTION
The RFC822 "mail" date format allows "GMT" to refer to +0000, or "UT", but it does not allow "UTC". This makes the RSS feed generated by CPAN-Testers-WWW-Reports invalid, which some RSS readers may now be treating more seriously (looking at you Thunderbird).

Thanks @nigelhorne for reporting this issue